### PR TITLE
Build a Docker image for the SP3 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,13 @@ services:
   - docker
 
 script:
-  - docker build -t libyui-test-image .
+  # at least run a syntax check for the Travis script
+  - bash -n libyui-travis
+  # build the Docker image
+  - docker build -t libyui-test-image -f Dockerfile.$DOCKER_TAG .
+
+env:
+  # define the build matrix to build all images in parallel
+  - DOCKER_TAG=latest
+  - DOCKER_TAG=sle12-sp3
+

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -4,6 +4,11 @@ FROM opensuse:tumbleweed
 # the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
 RUN zypper mr -d non-oss
 
+# "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed)
+# to avoid possible dependency issues as the TW Docker image is updated less frequently
+RUN zypper --gpg-auto-import-keys --non-interactive dup --no-recommends \
+  && zypper clean -a
+
 # add the YaST repository - we need the Rubocop gem for libyui/libyui-rake
 RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -1,0 +1,69 @@
+# SLE12-SP3 is officially not available at the Docker Hub
+# because of some licensing issues, use openSUSE-42.3 as a replacement.
+# It shares the same core packages and should be close enough to SLE12-SP3
+# for running the libyui builds.
+# FIXME: for now use the TW base, 42.3 (beta) has not been published yet,
+# after releasing 42.3 update this line to:
+# FROM opensuse:42.3
+FROM opensuse:tumbleweed
+
+# the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
+RUN zypper mr -d non-oss
+
+# Reuse the YaST SP3 repository, we do not want to maintain extra devel:libraries:libyui:SLE-12:SP3
+# subproject.
+#
+# Set a higher priority for the sle_12_sp3 repo to prefer the packages from
+# this repo even if they have a lower version than the original 42.3 packages.
+# FIXME: use the TW build target for now, later switch to:
+# RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/SLE_12_SP3/ \
+RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/openSUSE_Tumbleweed/ \
+  sle12_sp3
+
+# we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
+# why we need "zypper clean -a" at the end
+RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  ruby && zypper clean -a
+
+RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
+  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  boost-devel \
+  cmake \
+  doxygen \
+  fontconfig-devel \
+  gcc-c++ \
+  git \
+  gtk3-devel \
+  libyui-devel \
+  libyui-ncurses-devel \
+  libyui-qt-devel \
+  libzypp-devel \
+  obs-service-source_validator \
+  pkg-config \
+  'pkgconfig(Qt5Core)' \
+  'pkgconfig(Qt5Gui)' \
+  'pkgconfig(Qt5Svg)' \
+  'pkgconfig(Qt5Widgets)' \
+  'pkgconfig(Qt5X11Extras)' \
+  "rubygem($RUBY_VERSION:libyui-rake)" \
+  "rubygem($RUBY_VERSION:rubocop)" \
+  rpm-build \
+  yast2-devtools \
+  which \
+  && zypper clean -a \
+  && rm -rf /usr/lib64/ruby/gems/*/cache
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY libyui-travis /usr/local/bin
+
+# run some smoke tests to make sure there is no serious issue with the image
+RUN c++ --version
+
+# this is a bit tricky as the libyui/rake loads some files at the initialization
+RUN mkdir -p package && echo > package/test.spec && \
+  echo -e 'SET(VERSION_MAJOR "42")\nSET(VERSION_MINOR "42")\nSET(VERSION_PATCH "42")' \
+  > VERSION.cmake && rake -t -r libyui/rake -V && rm -rf package && rm VERSION.cmake

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ for running the CI tests at [Travis](https://travis-ci.org/).
 The built image is available at the [libyui/devel](
 https://hub.docker.com/r/libyui/devel) Docker repository.
 
+## Docker Tags
+
+This repository builds several versions of the image which are published
+by the Docker Hub with a different tag.
+
+The images are defined in the `Dockerfile.<tag>` files and published as
+`libyui/devel:<tag>` at the Docker Hub. See the complete [list of tags](
+https://hub.docker.com/r/libyui/devel/tags/) at the Docker Hub.
+
 ## Automatic Rebuilds
 
 - The image is rebuilt whenever a commit it pushed to the `master` branch.
@@ -30,7 +39,7 @@ a broken build you can trigger rebuild manually.
 
 - Go to the [Build Settings](
 https://hub.docker.com/r/libyui/devel/~/settings/automated-builds/) tab
-and press the *Trigger* button next to the *master* branch configuration line.
+and press the *Trigger* button for the required Docker image.
 
 - If you need to trigger the build from a script check the *Build Triggers*
 section at the bottom, press the *Show examples* link to display the `curl`
@@ -39,12 +48,12 @@ do not put it in a publicly visible place.)
 
 ## The Image Content
 
-This image is based on the latest openSUSE Tumbleweed image, additionally
-it contains the packages needed for building the libyui packages.
+The images contain all development packages needed for building the libyui
+packages.
 
 ## Using the image
 
-The image contains an `libyui-travis` script which runs all the checks and tests.
+The images contain an `libyui-travis` script which runs all the checks and tests.
 
 The workflow is:
 


### PR DESCRIPTION
- This is similar to the YaST approach - define separate `Dockerfile` for each image
- For now it still uses Tumbleweed internally as the 42.3 Docker images are not available yet (this should be fixed after the release)
- The SP3 `Dockerfile` is based on the original Docker image, only the repository setup has been changed and removed the `libyui-gtk-devel` package because it is missing in the YaST:SLE-12:SP3 repository (it is missing in SLE12-SP3 anyway, so not a problem)
- For SP3 we reuse the YaST SP3 repository which already includes the libyui SP3 packages (less maintenance), no need for a separate libyui:SP3 subproject
- Run `zypper dup` in the TW image (just like the YaST images)
- Updated `README.md`