### PR TITLE
Replace opensuse:tumbleweed with opensuse/tumbleweed

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,5 +1,5 @@
 # Build the latest openSUSE Tumbleweed image
-FROM opensuse:tumbleweed
+FROM opensuse/tumbleweed
 
 # the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
 RUN zypper mr -d "NON OSS"


### PR DESCRIPTION
We should not merge this change yet. ~Additionally, I wonder if we should update `opensuse:42.3` to `opensuse/42.3`.~

See https://lists.opensuse.org/opensuse-factory/2018-03/msg00389.html