### PR TITLE
Image cleanup, remove useless files

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,6 +1,9 @@
 # Build the latest openSUSE Tumbleweed image
 FROM opensuse/tumbleweed
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
 RUN zypper mr -d repo-non-oss
 
@@ -53,7 +56,8 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   yast2-devtools \
   which \
   && zypper clean -a \
-  && rm -rf /usr/lib64/ruby/gems/*/cache
+  && rm -rf /usr/lib*/ruby/gems/*/cache \
+  && rm -rf /usr/share/doc/
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -4,6 +4,9 @@
 # for running the libyui builds.
 FROM opensuse:42.3
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
 RUN zypper mr -d "NON OSS"
 
@@ -52,7 +55,8 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   yast2-devtools \
   which \
   && zypper clean -a \
-  && rm -rf /usr/lib64/ruby/gems/*/cache
+  && rm -rf /usr/lib*/ruby/gems/*/cache \
+  && rm -rf /usr/share/doc/
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile.sle12-sp4
+++ b/Dockerfile.sle12-sp4
@@ -5,6 +5,9 @@
 # for running the libyui builds.
 FROM opensuse:42.3
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
 RUN zypper mr -d "NON OSS"
 
@@ -53,7 +56,8 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   yast2-devtools \
   which \
   && zypper clean -a \
-  && rm -rfv /usr/lib64/ruby/gems/*/cache
+  && rm -rf /usr/lib*/ruby/gems/*/cache \
+  && rm -rf /usr/share/doc/
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile.sle15
+++ b/Dockerfile.sle15
@@ -1,6 +1,9 @@
 # Build the latest openSUSE Tumbleweed image
 FROM opensuse/leap:15.0
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # the NON-OSS repo is not needed, save the network bandwidth and some time (~5 seconds) for each refresh
 RUN zypper mr -d repo-non-oss repo-update-non-oss
 
@@ -56,7 +59,8 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   yast2-devtools \
   which \
   && zypper clean -a \
-  && rm -rfv /usr/lib64/ruby/gems/*/cache
+  && rm -rf /usr/lib*/ruby/gems/*/cache \
+  && rm -rf /usr/share/doc/
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Similar to https://github.com/yast/docker-yast-ruby/pull/24

- Do not install the documentation
- Remove the Rubygem cache
- The final SLE15 image is about 90MB smaller
- Travis should be a bit faster