### PR TITLE
Enable code coverage reporting

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -38,6 +38,7 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   gcc-c++ \
   git \
   gtk3-devel \
+  lcov \
   libyui-devel \
   libyui-gtk-devel \
   libyui-ncurses-devel \
@@ -50,6 +51,7 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   'pkgconfig(Qt5Svg)' \
   'pkgconfig(Qt5Widgets)' \
   'pkgconfig(Qt5X11Extras)' \
+  "rubygem($RUBY_VERSION:coveralls-lcov)" \
   "rubygem($RUBY_VERSION:libyui-rake)" \
   "rubygem($RUBY_VERSION:rubocop)" \
   rpm-build \

--- a/libyui-travis
+++ b/libyui-travis
@@ -12,7 +12,7 @@ rake tarball
 # Moreover it does not work in a Docker container (it fails when trying to mount
 # /proc and /sys in the chroot).
 cp package/* /usr/src/packages/SOURCES/
-rpmbuild -bb -D "jobs `nproc`" --nodeps package/*.spec
+rpmbuild -bb -D "jobs `nproc`" --with coverage --nodeps package/*.spec
 
 # test the %pre/%post scripts by installing/updating/removing the built packages
 # ignore the dependencies to make the test easier, as a smoke test it's good enough
@@ -21,3 +21,13 @@ rpm -Uv --force --nodeps /usr/src/packages/RPMS/*/*.rpm
 
 # get the plain package names and remove all packages at once
 rpm -ev --nodeps `rpm -q --qf '%{NAME} ' -p /usr/src/packages/RPMS/**/*.rpm`
+
+# is coverage data present?
+coverage=`find /usr/src/packages/BUILD -name coverage.info -print -quit`
+if [ -n "$coverage" ]; then
+  # strip the absolute path prefix from the coverage data so coveralls.io
+  # can find the source files at GitHub
+  sed -i "$coverage" -e 's#^SF:/usr/src/packages/BUILD/libyui-\([^/]*\)/\(.*\)$#SF:\2#'
+  # send the code coverage to coveralls.io, the token is expected in $COVERALLS_TOKEN
+  LC_ALL=en_US.UTF-8 coveralls-lcov --repo-token "$COVERALLS_TOKEN" "$coverage"
+fi


### PR DESCRIPTION
- Install `lcov` and `rubygem-coveralls-lcov packages`
- Adapted the Docker script

Example Travis output: https://travis-ci.org/libyui/libyui/builds/407007736#L4088
Example coverage report: https://coveralls.io/builds/18109974

Note: The related change in the libyui is here: https://github.com/libyui/libyui/pull/129