### PR TITLE
Run "rake package" instead of simpler "rake tarball"

### DIFF
--- a/libyui-travis
+++ b/libyui-travis
@@ -2,7 +2,8 @@
 
 set -e -x
 
-rake tarball
+# check the license and changelog then build the tarball
+rake package
 
 # run the osc source validator to check the .spec and .changes locally
 (cd package && /usr/lib/obs/service/source_validator)


### PR DESCRIPTION
It also checks license and bug number, it is part of the "rake osc:sr" called at Jenkins later.

This makes the Travis run more close to Jenkins.