### PR TITLE
Added BRP packages to be more compatible with "osc build"

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -35,6 +35,8 @@ RUN rpm --import https://build.opensuse.org/projects/devel:libraries:libyui/publ
 RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   boost-devel \
+  brp-check-suse \
+  brp-extract-appdata \
   cmake \
   doxygen \
   fontconfig-devel \


### PR DESCRIPTION
This is similar to https://github.com/yast/docker-yast-ruby/pull/31, check it for more details.