### PR TITLE
Do not use the devel:libraries:libyui repository for SLE15 image

### DIFF
--- a/Dockerfile.sle15
+++ b/Dockerfile.sle15
@@ -29,12 +29,6 @@ RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-15:/
 # import the YaST OBS GPG key
 RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
 
-# prefer the packages from the libyui devel project
-RUN zypper ar -f -p 50 http://download.opensuse.org/repositories/devel:/libraries:/libyui/openSUSE_Leap_15.0/ libyui
-
-# import the libyui OBS GPG key
-RUN rpm --import https://build.opensuse.org/projects/devel:libraries:libyui/public_key
-
 RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --non-interactive in --no-recommends \
   boost-devel \
@@ -43,9 +37,7 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   fontconfig-devel \
   gcc-c++ \
   git \
-  gtk3-devel \
   libyui-devel \
-  libyui-gtk-devel \
   libyui-ncurses-devel \
   libyui-qt-devel \
   libzypp-devel \

--- a/Dockerfile.sle15-sp1
+++ b/Dockerfile.sle15-sp1
@@ -26,12 +26,6 @@ RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-15:/
 # import the YaST OBS GPG key
 RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
 
-# prefer the packages from the libyui devel project
-RUN zypper ar -f -p 50 http://download.opensuse.org/repositories/devel:/libraries:/libyui/openSUSE_Leap_15.1/ libyui
-
-# import the libyui OBS GPG key
-RUN rpm --import https://build.opensuse.org/projects/devel:libraries:libyui/public_key
-
 RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --non-interactive in --no-recommends \
   boost-devel \
@@ -40,9 +34,7 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   fontconfig-devel \
   gcc-c++ \
   git \
-  gtk3-devel \
   libyui-devel \
-  libyui-gtk-devel \
   libyui-ncurses-devel \
   libyui-qt-devel \
   libzypp-devel \


### PR DESCRIPTION
- This should fix the Travis issues in the SLE15 branch ([like this one](https://travis-ci.org/libyui/libyui-qt-pkg/builds/547642530))
- Do not use the devel:libraries:libyui repository for SLE15, it contains libyui10 packages from master which are not compatible with the libyui9 packages in SLE15 GA and SP1.
- Use the packages from the YaST:SLE-15 and YaST:SLE-15:SP1 repositories,
they contain the correct SLE packages.
- I had to remove the GTK packages because they are missing there, but should not be a problem as they are not supported in SLE15 anyway